### PR TITLE
Add simple Flask web UI for running nmap scans

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -1,0 +1,25 @@
+# Nmap Web UI
+
+This directory provides a minimal Flask application that exposes a simple web
+interface for running `nmap` scans.
+
+## Usage
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Start the application:
+
+   ```bash
+   python app.py
+   ```
+
+3. Open a browser and visit `http://localhost:5000`. Enter the target host and
+   any additional Nmap options. The scan results will be displayed on the page.
+
+`nmap` must be installed and available on the system path for scans to run
+successfully.
+

--- a/webui/app.py
+++ b/webui/app.py
@@ -1,10 +1,23 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, request
+import subprocess
 
 app = Flask(__name__)
 
-@app.route('/')
+
+@app.route('/', methods=['GET', 'POST'])
 def index():
-    return render_template('index.html')
+    output = None
+    if request.method == 'POST':
+        target = request.form.get('target')
+        options = request.form.get('options', '')
+        if target:
+            cmd = ['nmap'] + options.split() + [target]
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+                output = result.stdout
+            except subprocess.CalledProcessError as e:
+                output = e.stdout + e.stderr
+    return render_template('index.html', output=output)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/webui/templates/index.html
+++ b/webui/templates/index.html
@@ -5,7 +5,17 @@
     <title>Nmap Web UI</title>
 </head>
 <body>
-    <h1>Welcome to Nmap Web UI</h1>
-    <p>This is a simple web interface for Nmap.</p>
+    <h1>Nmap Web UI</h1>
+    <form method="post">
+        <label for="target">Target:</label>
+        <input type="text" id="target" name="target" required>
+        <label for="options">Options:</label>
+        <input type="text" id="options" name="options" placeholder="-sV">
+        <button type="submit">Scan</button>
+    </form>
+    {% if output %}
+    <h2>Results</h2>
+    <pre>{{ output }}</pre>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Flask endpoint to run `nmap` with user-provided target and options
- show scan results in the web page
- document usage of the web UI

## Testing
- `python -m py_compile webui/app.py`
- `nmap -sn localhost`


------
https://chatgpt.com/codex/tasks/task_e_68b227dbbfd4832a80aba28c758079ac